### PR TITLE
Improvement/add three phase definitions

### DIFF
--- a/src/sunsynk/definitions/three_phase_common.py
+++ b/src/sunsynk/definitions/three_phase_common.py
@@ -288,7 +288,35 @@ SENSORS += (
 # System program
 #################
 
-SENSORS += SwitchRWSensor(141, "Priority Load")
+SENSORS += (
+    SelectRWSensor(
+        141,
+        "Priority Load",
+        options={
+            0b10 << 0: "Battery First",
+            0b11 << 0: "Load First",
+        },
+        bitmask=0b11 << 0,
+    ),
+    SelectRWSensor(
+        141,
+        "Passive Grid Balance",
+        options={
+            0b10 << 2: "Close",
+            0b11 << 2: "Open",
+        },
+        bitmask=0b11 << 2,
+    ),
+    SelectRWSensor(
+        141,
+        "Active Grid Balance",
+        options={
+            0b10 << 4: "Close",
+            0b11 << 4: "Open",
+        },
+        bitmask=0b11 << 4,
+    ),
+)
 
 SENSORS += SelectRWSensor(
     142,

--- a/src/sunsynk/definitions/three_phase_common.py
+++ b/src/sunsynk/definitions/three_phase_common.py
@@ -32,7 +32,12 @@ SENSORS += (
     Sensor(633, "Inverter L1 power", WATT, -1),
     Sensor(634, "Inverter L2 power", WATT, -1),
     Sensor(635, "Inverter L3 power", WATT, -1),
-    Sensor(627, "Inverter voltage", VOLT, 0.1),
+    Sensor(627, "Inverter L1 voltage", VOLT, 0.1),
+    Sensor(628, "Inverter L2 voltage", VOLT, 0.1),
+    Sensor(629, "Inverter L3 voltage", VOLT, 0.1),
+    Sensor(630, "Inverter L1 current", AMPS, -0.01),
+    Sensor(631, "Inverter L2 current", AMPS, -0.01),
+    Sensor(632, "Inverter L3 current", AMPS, -0.01),
     Sensor(638, "Inverter frequency", "Hz", 0.01),
 )
 

--- a/src/sunsynk/definitions/three_phase_common.py
+++ b/src/sunsynk/definitions/three_phase_common.py
@@ -218,11 +218,13 @@ SENSORS += (
         options={0: "Use Battery Voltage", 1: "Lithium (Use BMS)", 2: "No Battery"},
     ),
     SelectRWSensor(
+        # according to docs, 0 is enabled for this one, but reported to be wrong:
+        # https://github.com/kellerza/sunsynk/issues/381#issuecomment-2568995917
         112,
         "Battery Wake Up",
-        options={0: "Enabled", 1 << 0: "Disabled"},
+        options={0: "Disabled", 1 << 0: "Enabled"},
         bitmask=1 << 0,
-    ),  # according to docs, 0 is enabled for this one
+    ),
     NumberRWSensor(113, "Battery Resistance", "mΩ", max=6000),
     Sensor(114, "Battery Charge Efficiency", "%", 0.1),
     SelectRWSensor(

--- a/src/sunsynk/definitions/three_phase_common.py
+++ b/src/sunsynk/definitions/three_phase_common.py
@@ -81,6 +81,22 @@ SENSORS += (
 )
 
 ##############
+# Gen Power
+##############
+SENSORS += (
+    Sensor(667, "Gen power", WATT, 1),
+    Sensor(664, "Gen L1 power", WATT, 1),
+    Sensor(665, "Gen L2 power", WATT, 1),
+    Sensor(666, "Gen L3 power", WATT, 1),
+    Sensor(661, "Gen L1 voltage", VOLT, 0.1),
+    Sensor(662, "Gen L2 voltage", VOLT, 0.1),
+    Sensor(663, "Gen L3 voltage", VOLT, 0.1),
+    Sensor(671, "Gen L1 current", AMPS, -0.01),
+    Sensor(672, "Gen L2 current", AMPS, -0.01),
+    Sensor(673, "Gen L3 current", AMPS, -0.01),
+)
+
+##############
 # Solar Power
 ##############
 SENSORS += (

--- a/src/sunsynk/definitions/three_phase_common.py
+++ b/src/sunsynk/definitions/three_phase_common.py
@@ -302,8 +302,8 @@ SENSORS += (
         141,
         "Passive Grid Balance",
         options={
-            0b10 << 2: "Close",
-            0b11 << 2: "Open",
+            0b10 << 2: "Disabled",
+            0b11 << 2: "Enabled",
         },
         bitmask=0b11 << 2,
     ),
@@ -311,8 +311,8 @@ SENSORS += (
         141,
         "Active Grid Balance",
         options={
-            0b10 << 4: "Close",
-            0b11 << 4: "Open",
+            0b10 << 4: "Disabled",
+            0b11 << 4: "Enabled",
         },
         bitmask=0b11 << 4,
     ),


### PR DESCRIPTION
# Priority Load and Grid Balance Sensor Definitions Update

## Description
This PR updates the sensor definitions for Priority Load and Grid Balance settings in the three-phase inverter models. The changes improve the register usage by properly implementing all available bits as per the documentation.

### Changes
- Updated register 141 to use all available bits (Related issue: https://github.com/kellerza/sunsynk/issues/376):
  - Bits 0-1: Priority Load mode (Battery First/Load First)
  - Bits 2-3: Passive Grid Balance (Disabled/Enabled)
  - Bits 4-5: Active Grid Balance (Disabled/Enabled)
- Each setting uses its own bitmask to operate independently
- Maintains backward compatibility with existing Priority Load functionality
- Uses consistent bit patterns (10 for first option, 11 for second option)
- This PR also fixes wrong definition of Battery Wakeup setting
  - As per https://github.com/kellerza/sunsynk/issues/381#issuecomment-2568995917
- Initial sensors for Gen (Generator) monitoring, soon for control and config

### Technical Details
- Each setting uses SelectRWSensor with appropriate bitmasks
- Bitmask values:
  - Priority Load: `0b11 << 0`
  - Passive Grid Balance: `0b11 << 2`
  - Active Grid Balance: `0b11 << 4`
- All settings share register 141 but operate on different bits

### Documentation
The implementation follows the inverter documentation which specifies:
- Bits 0-1: Priority mode selection
- Bits 2-3: Passive grid-connected power balance
- Bits 4-5: Active grid-connection power balance

This update provides better control over grid balance features while maintaining existing functionality.