### PR TITLE
Add 'Track Grid Phase' option to sensor definitions and update documentation

### DIFF
--- a/src/ha_addon_sunsynk_multi/sensor_options.py
+++ b/src/ha_addon_sunsynk_multi/sensor_options.py
@@ -273,6 +273,7 @@ SENSOR_GROUPS: dict[str, list[str]] = {
         "grid_standard",
         "configured_grid_frequency",
         "configured_grid_phases",
+        "track_grid_phase",
         "ups_delay_time",
     ],
     "generator": [

--- a/src/sunsynk/definitions/three_phase_common.py
+++ b/src/sunsynk/definitions/three_phase_common.py
@@ -551,6 +551,14 @@ SENSORS += (  ### no idea why there is a "no work" option, but it's in the spec
         },
         bitmask=0b11 << 14,
     ),
+    SelectRWSensor(
+        235,
+        "Track Grid Phase",
+        options={
+            0: "Disable",
+            1: "Enable",
+        },
+    ),
     NumberRWSensor(209, "UPS delay time", "s"),
 )
 ############

--- a/www/docs/reference/definitions.md
+++ b/www/docs/reference/definitions.md
@@ -210,6 +210,7 @@ battery_charge_efficiency
 grid_standard
 configured_grid_frequency
 configured_grid_phases
+track_grid_phase
 ups_delay_time
 ```
 


### PR DESCRIPTION
- Added 'track_grid_phase' to SENSOR_GROUPS in sensor_options.py.
- Introduced a new SelectRWSensor for 'Track Grid Phase' in three_phase_common.py with options to enable or disable.
- Updated definitions documentation to include 'track_grid_phase' for clarity.